### PR TITLE
Drop passPerPreset

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,8 @@
 {
-  "passPerPreset": true,
   "presets": [
-    "react",
     "es2015",
-    "stage-0"
+    "stage-0",
+    "react"
   ],
   "plugins": [
     "babel-plugin-inline-import"


### PR DESCRIPTION
cc @loganfsmyth

This is partly for discussion. I was going through GitHub repos looking for instances of `passPerPreset`, and found a number of hits in Apollo-related code.

I believe the addition of `passPerPreset` here came from some old Relay stuff, via https://github.com/apollographql/apollo-server-tutorial/commit/243357f2ca92efd2a024d6652f61519d463164e9.

It turns out the recommendation for `passPerPreset` with Relay was due to some misunderstandings about how Babel worked, and in fact `passPerPreset` was not necessary there: https://github.com/relayjs/relay-starter-kit/pull/102

Unless there are compelling reasons to continue to use `passPerPreset` here, we should also remove `passPerPreset` from Apollo examples.

`passPerPreset` is a little bit weird and is not really commonly used, and correspondingly occasionally hits weird bugs that don't come up otherwise: https://github.com/babel/babel/issues/4162. As such, it would be best to minimize its usage, especially where it's not actually needed.