### PR TITLE
Fixed bug with subscription notifications not being sent out

### DIFF
--- a/data/swapiSchema.js
+++ b/data/swapiSchema.js
@@ -434,7 +434,7 @@ const resolvers = {
             () => pubsub.asyncIterator(ADDED_REVIEW_TOPIC),
             (payload, variables) => {
                 return (payload !== undefined) && 
-                ((variables.episode === null) || (payload.reviewAdded.episode === variables.episode));
+                (!variables.episode || (payload.reviewAdded.episode === variables.episode));
             }
         ),
     },


### PR DESCRIPTION
<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->

Fix for #19 